### PR TITLE
Add React frontend landing page

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,1 +1,12 @@
 # FriendFinder Frontend
+
+Dette er en simpel React-applikation lavet med [Vite](https://vitejs.dev/).
+
+## Kom i gang
+
+Installer afhængigheder og start udviklingsserveren:
+
+```bash
+npm install
+npm run dev
+```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FriendFinder</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,19 @@
 {
   "name": "friendfinder-frontend",
   "private": true,
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0"
+  }
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,14 @@
+.app {
+  text-align: center;
+  padding: 2rem;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+button {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  cursor: pointer;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import './App.css'
+
+function App() {
+  return (
+    <main className="app">
+      <h1>FriendFinder</h1>
+      <p>Find nye venner baseret på dine interesser og værdier.</p>
+      <button>Kom i gang</button>
+    </main>
+  )
+}
+
+export default App

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,10 @@
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background-color: #f0f0f0;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- scaffold a Vite-based React project under `frontend`
- implement landing page with heading, description and button
- document frontend usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685832860a64832ea5435f7d24e791e7