### PR TITLE
Add signup page and routing

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.14.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -12,3 +12,11 @@ button {
   font-size: 1rem;
   cursor: pointer;
 }
+
+.signup-page div {
+  margin-bottom: 0.5rem;
+}
+
+.signup-page input {
+  margin-left: 0.5rem;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,13 +1,19 @@
 import React from 'react'
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import './App.css'
+import Home from './pages/Home'
+import Signup from './pages/Signup'
+import Onboarding from './pages/Onboarding'
 
 function App() {
   return (
-    <main className="app">
-      <h1>FriendFinder</h1>
-      <p>Find nye venner baseret på dine interesser og værdier.</p>
-      <button>Kom i gang</button>
-    </main>
+    <Router>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/signup" element={<Signup />} />
+        <Route path="/onboarding" element={<Onboarding />} />
+      </Routes>
+    </Router>
   )
 }
 

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import '../App.css'
+
+function Home() {
+  return (
+    <main className="app">
+      <h1>FriendFinder</h1>
+      <p>Find nye venner baseret på dine interesser og værdier.</p>
+      <Link to="/signup">
+        <button>Kom i gang</button>
+      </Link>
+    </main>
+  )
+}
+
+export default Home

--- a/frontend/src/pages/Onboarding.jsx
+++ b/frontend/src/pages/Onboarding.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+function Onboarding() {
+  return (
+    <div className="onboarding-page">
+      <h2>Onboarding</h2>
+      <p>Her kommer spørgeskemaet.</p>
+    </div>
+  )
+}
+
+export default Onboarding

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+function Signup() {
+  const [name, setName] = useState('')
+  const [age, setAge] = useState('')
+  const [city, setCity] = useState('')
+  const [email, setEmail] = useState('')
+  const navigate = useNavigate()
+
+  const handleNext = () => {
+    navigate('/onboarding')
+  }
+
+  return (
+    <div className="signup-page">
+      <h2>Tilmeld dig</h2>
+      <div>
+        <label>
+          Navn:
+          <input
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Alder:
+          <input
+            type="number"
+            value={age}
+            onChange={e => setAge(e.target.value)}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          By:
+          <input
+            type="text"
+            value={city}
+            onChange={e => setCity(e.target.value)}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Email:
+          <input
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+          />
+        </label>
+      </div>
+      <button onClick={handleNext}>Næste</button>
+    </div>
+  )
+}
+
+export default Signup


### PR DESCRIPTION
## Summary
- add react-router-dom dependency
- add router with Home, Signup and Onboarding pages
- implement `/signup` form using local state
- add placeholder onboarding page
- basic styles for signup inputs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858367f50ac832eba859eab66499ae5