### PR TITLE
Add minimal Flask backend

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,1 +1,9 @@
 # FriendFinder Backend
+
+Dette bibliotek indeholder en simpel Flask-app. Start serveren med:
+
+```bash
+python main.py
+```
+
+Serveren lytter på `/submit-profile` og logger modtagne data i konsollen.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,24 @@
 # Entry-point for the backend server
 
 
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+
+
 def create_app():
     """Initialize the backend application."""
-    pass
+    app = Flask(__name__)
+    CORS(app)
+
+    @app.route("/submit-profile", methods=["POST"])
+    def submit_profile():
+        data = request.get_json(silent=True) or {}
+        app.logger.info("Received profile data: %s", data)
+        return jsonify({"status": "success"}), 200
+
+    return app
 
 
 if __name__ == "__main__":
-    create_app()
+    app = create_app()
+    app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- implement a very small Flask API with CORS enabled
- document how to run the backend

## Testing
- `python backend/main.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685838f0d1e8832e93be374a96a3b56a